### PR TITLE
Register dashboard strategy via customStrategies array

### DIFF
--- a/src/apple-home-strategy.ts
+++ b/src/apple-home-strategy.ts
@@ -27,7 +27,7 @@ injectLiquidGlassStyles();
 declare global {
   interface Window {
     customCards?: any[];
-    customStrategies?: { [key: string]: any };
+    customStrategies?: any[];
     appleHomeCleanupRegistered?: boolean;
   }
 }
@@ -250,8 +250,14 @@ if (window.customCards) {
   });
 }
 
-// Also register the function for backward compatibility
-window.customStrategies = window.customStrategies || {};
-window.customStrategies['apple-home-strategy'] = generateLovelaceDashboard;
+// Register the strategy with Home Assistant
+window.customStrategies = window.customStrategies || [];
+window.customStrategies.push({
+  type: 'apple-home-strategy',
+  strategyType: 'dashboard',
+  name: 'Apple Home Dashboard',
+  description: 'Apple Home-style dashboard auto-generated from your Home Assistant entities.',
+  documentationURL: 'https://github.com/nitaybz/apple-home-dashboard',
+});
 
 


### PR DESCRIPTION
## Summary

- Migrate strategy registration to the new `window.customStrategies` array API announced in the [Home Assistant developer blog post](https://developers.home-assistant.io/blog/2026/04/21/registering-custom-dashboard-strategies/).
- Provide proper metadata (`name`, `description`, `documentationURL`) so the dashboard appears in Home Assistant's strategy picker UI instead of requiring users to hand-write YAML.
- Update the `Window.customStrategies` type declaration from object-map to array to match the new API.

Previously the strategy was registered via `window.customStrategies['apple-home-strategy'] = generateLovelaceDashboard`, which is the older object-map form. The new API is an array of registration descriptors, and it's what HA will use to populate the "Take control" → strategy selection UI going forward.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Load the built bundle in Home Assistant and confirm the strategy still generates the dashboard as before
- [ ] Confirm "Apple Home Dashboard" appears in the strategy picker when creating a new dashboard