### PR TITLE
fix(security): don't hide cameras from Security view when their room is hidden

### DIFF
--- a/src/pages/GroupPage.ts
+++ b/src/pages/GroupPage.ts
@@ -159,9 +159,14 @@ export class GroupPage {
       // Batch-fetch exclusion list once, then filter synchronously
       const excludedFromDashboard = new Set(await this.customizationManager?.getExcludedFromDashboard() || []);
 
-      const filteredEntities = supportedEntities.filter(entity =>
-        !excludedFromDashboard.has(entity.entity_id) && !this.isEntityInHiddenArea(entity, devices, hiddenSections)
-      );
+      // Cameras are exempt from room-hidden filtering: hiding a room from the Home page
+      // is meant to declutter that grid, not to remove its cameras from Security. Cameras
+      // are only removed here via the explicit "Exclude from Dashboard" list.
+      const filteredEntities = supportedEntities.filter(entity => {
+        if (excludedFromDashboard.has(entity.entity_id)) return false;
+        if (DashboardConfig.isCamerasDomain(entity.entity_id.split('.')[0])) return true;
+        return !this.isEntityInHiddenArea(entity, devices, hiddenSections);
+      });
       const filteredStatusEntities = statusEntities.filter(entity =>
         !excludedFromDashboard.has(entity.entity_id) && !this.isEntityInHiddenArea(entity, devices, hiddenSections)
       );

--- a/src/pages/GroupPage.ts
+++ b/src/pages/GroupPage.ts
@@ -438,9 +438,12 @@ export class GroupPage {
       });
     }
     
-    // Render sections in order, respecting visibility settings
+    // Render sections in order, respecting visibility settings. The Cameras bucket is
+    // exempt: hiding it declutters the Home page grid, but this method only ever
+    // receives cameras for the Security page, where they should stay reachable.
     for (const sectionId of orderedSectionIds) {
-      if (!hiddenSections.includes(sectionId) && availableSections.has(sectionId)) {
+      const isHidden = sectionId !== 'cameras_section' && hiddenSections.includes(sectionId);
+      if (!isHidden && availableSections.has(sectionId)) {
         await availableSections.get(sectionId)!();
       }
     }


### PR DESCRIPTION
## Summary
Hiding cameras via the section reorder modal removed them from the Security chip's view too — even though "hide" here is meant to declutter the Home page grid, not make cameras unreachable for monitoring. Two related gaps, both in `GroupPage.ts`:

1. Hiding a **room** that contains a camera set that room's area id in `hiddenSections`, which `GroupPage`'s per-entity filter applied to every group page, including Security.
2. Hiding the **"Cameras" bucket itself** (as a whole section, confirmed via testing on the live dashboard) set `'cameras_section'` in `hiddenSections`, which a separate, generic section-visibility loop used to skip rendering the entire cameras block — again including on Security.

Both are now exempted on `GroupPage`: cameras are only removed from Security via the existing explicit "Exclude from Dashboard" list, matching how "remove everywhere" already works for every other entity.

## Test plan
- [x] Hide the whole "Cameras" section via Reorder Sections; confirm cameras disappear from the Home page grid but still show up when tapping the Security chiclet. (Verified live on a real dashboard.)
- [ ] Hide a room containing a camera via the same modal; confirm the same behavior (camera still visible in Security).
- [ ] Add a camera to "Exclude from Dashboard" in Home Settings; confirm it now disappears from Security too.
- [ ] Confirm non-camera entities in a hidden room still don't appear on other group pages (behavior unchanged).