### PR TITLE
feat(header): move home name into the always-visible top bar

### DIFF
--- a/src/components/AppleHomeView.ts
+++ b/src/components/AppleHomeView.ts
@@ -558,7 +558,8 @@ export class AppleHomeView extends HTMLElement {
       const homeConfig: HeaderConfig = {
         title: this.config.title || localize('pages.my_home'),
         isGroupPage: false,
-        showMenu: true
+        showMenu: true,
+        alwaysShowTitle: true
       };
       await this.appleHeader.init(this.content, homeConfig);
       // Update page content padding after header is initialized
@@ -2193,7 +2194,6 @@ export class AppleHomeView extends HTMLElement {
         await this.homePage.render(
           this.content,
           this._hass,
-          homeTitle,
           (entityId: string, areaId: string) => this.toggleTallCard(entityId, areaId)
         );
       }

--- a/src/pages/HomePage.ts
+++ b/src/pages/HomePage.ts
@@ -52,34 +52,19 @@ export class HomePage {
     }
   }
 
-  private createHomeTitle(title: string): HTMLElement {
-    const titleElement = document.createElement('h1');
-    titleElement.className = 'apple-page-title';
-    titleElement.textContent = title;
-    return titleElement;
-  }
-
   async render(
     container: HTMLElement,
     hass: any,
-    title: string,
     onTallToggle?: (entityId: string, areaId: string) => void | Promise<void | boolean>
   ): Promise<void> {
     // Remove only dynamic content, keep permanent elements (header, chips) in place
+    // The home name is shown in the always-visible header instead of an in-page title,
+    // to save vertical space (see AppleHeader's alwaysShowTitle).
     const permanentSelectors = ['.apple-home-header', '.permanent-chips'];
     Array.from(container.children).forEach(child => {
       const isPermanent = permanentSelectors.some(sel => child.matches(sel));
       if (!isPermanent) child.remove();
     });
-
-    // Add home title after header but before chips
-    const homeTitle = this.createHomeTitle(title);
-    const existingPermanentChips = container.querySelector('.permanent-chips');
-    if (existingPermanentChips) {
-      container.insertBefore(homeTitle, existingPermanentChips);
-    } else {
-      container.appendChild(homeTitle);
-    }
 
     try {
       // Fetch all data in parallel

--- a/src/sections/AppleHeader.ts
+++ b/src/sections/AppleHeader.ts
@@ -17,6 +17,7 @@ export interface HeaderConfig {
   showMenu: boolean;
   showBackButton?: boolean;
   chipsElement?: HTMLElement;
+  alwaysShowTitle?: boolean;
 }
 
 export class AppleHeader {
@@ -159,6 +160,9 @@ export class AppleHeader {
     if (!config.isGroupPage && this.scrolledChipsContainer) {
       this.scrolledChipsContainer.innerHTML = '';
     }
+
+    // Show the title without waiting for scroll (e.g. Home page, to save vertical space)
+    this.headerElement?.classList.toggle('always-show-title', !!config.alwaysShowTitle);
 
   }
 
@@ -506,6 +510,9 @@ export class AppleHeader {
     } else if (this.headerElement) {
       this.headerElement.classList.remove('group-page');
     }
+
+    // Show the title without waiting for scroll (e.g. Home page, to save vertical space)
+    this.headerElement?.classList.toggle('always-show-title', !!this.currentConfig.alwaysShowTitle);
 
     // Get references to the elements (whether existing or newly created)
     this.scrolledTitleElement = this.headerElement.querySelector('.apple-header-scrolled-title') as HTMLElement;
@@ -1731,11 +1738,13 @@ export class AppleHeader {
         margin-right: 0;
       }
 
-      .apple-home-header.scrolled {
+      .apple-home-header.scrolled,
+      .apple-home-header.always-show-title {
         background: transparent;
       }
 
-      .apple-home-header.scrolled::before {
+      .apple-home-header.scrolled::before,
+      .apple-home-header.always-show-title::before {
         content: '';
         position: absolute;
         top: 0;
@@ -1905,7 +1914,8 @@ export class AppleHeader {
         justify-content: center;
       }
 
-      .apple-home-header.scrolled .apple-header-scrolled {
+      .apple-home-header.scrolled .apple-header-scrolled,
+      .apple-home-header.always-show-title .apple-header-scrolled {
         opacity: 1;
         visibility: visible;
         pointer-events: auto;

--- a/src/sections/AppleHeader.ts
+++ b/src/sections/AppleHeader.ts
@@ -1929,7 +1929,7 @@ export class AppleHeader {
         }
 
       .apple-header-scrolled-title {
-        font-size: 17px;
+        font-size: 20px;
         font-weight: 600;
         color: #ffffff;
         margin: 0;
@@ -2259,9 +2259,9 @@ export class AppleHeader {
         }
 
         .apple-header-scrolled-title {
-          font-size: 16px;
+          font-size: 18px;
         }
-        
+
         /* Adjust padding for mobile fixed header */
         .page-content.has-fixed-header {
           padding-top: 60px; /* Slightly less on mobile */
@@ -2280,9 +2280,9 @@ export class AppleHeader {
         }
         
         .apple-header-scrolled-title {
-          font-size: 15px;
+          font-size: 17px;
         }
-        
+
         .apple-header-dropdown {
           width: 200px;
           right: 8px;
@@ -2306,9 +2306,9 @@ export class AppleHeader {
         }
         
         .apple-header-scrolled-title {
-          font-size: 14px;
+          font-size: 16px;
         }
-        
+
         .apple-header-dropdown {
           width: 180px;
           right: 6px;


### PR DESCRIPTION
## Summary
On small landscape wall panels, vertical space is scarce. The home name used to live in a large in-page title that scrolled away with content, while the header only revealed a matching title after scrolling past a threshold - wasting space for no benefit on these displays.

- Added `HeaderConfig.alwaysShowTitle`, enabled for the Home page, which shows the header title (and its glass background) immediately instead of waiting for scroll.
- Removed `HomePage`'s separate in-page title now that the header covers it.
- Bumped the header title's font size (17px -> 20px, with proportional bumps at each responsive breakpoint) so it reads at a similar scale to the 22px icons now flanking it permanently, since it went from an occasional post-scroll reveal to a constant fixture.
- Room/Group page titles are untouched - this only changes the Home page.

Verified live on a real dashboard (Zone Z).

## Test plan
- [x] Load the Home page: home name visible in the top bar immediately, no separate large title, no need to scroll. (Verified live.)
- [x] Title size reads comfortably against the flanking icons. (Verified live, adjusted after initial feedback.)
- [ ] Scroll the Home page: header should look the same as before (no visual regression once scrolled).
- [ ] Visit a Room page, Scenes page, and a Group (e.g. Security) page: titles behave as before (unaffected by this change).
- [ ] Check RTL layout: header title still renders correctly.