### PR TITLE
feat(header): add configurable custom header button

### DIFF
--- a/src/components/AppleHomeView.ts
+++ b/src/components/AppleHomeView.ts
@@ -2509,6 +2509,14 @@ export class AppleHomeView extends HTMLElement {
         didChange = true;
       }
 
+      // --- Custom header button ---
+      const headerButtonChanged =
+        oldHome.header_button_icon !== newHome.header_button_icon ||
+        oldHome.header_button_path !== newHome.header_button_path;
+      if (headerButtonChanged) {
+        this.appleHeader.refreshCustomButton();
+      }
+
       // --- Weather entity ---
       const weatherChanged = oldHome.weather_entity !== newHome.weather_entity;
       if (weatherChanged) {

--- a/src/sections/AppleHeader.ts
+++ b/src/sections/AppleHeader.ts
@@ -411,6 +411,7 @@ export class AppleHeader {
             </div>
             <div class="apple-header-scrolled-chips"></div>
           </div>
+          ${this.getCustomButtonHTML()}
           ${this.currentConfig.showMenu ? `
             <button class="apple-header-menu-button ${LiquidGlassClasses.headerButton}">
               ${this.getMenuButtonContent()}
@@ -470,6 +471,7 @@ export class AppleHeader {
               </div>
               <div class="apple-header-scrolled-chips"></div>
             </div>
+            ${this.getCustomButtonHTML()}
             ${this.currentConfig.showMenu ? `
               <button class="apple-header-menu-button ${LiquidGlassClasses.headerButton}">
                 ${this.getMenuButtonContent()}
@@ -551,6 +553,92 @@ export class AppleHeader {
       }, 300);
     });
 
+  }
+
+  /**
+   * User-configured extra header button (icon + navigation path), set via Home Settings.
+   */
+  private getHeaderButtonConfig(): { icon: string; path: string } | null {
+    if (!this.customizationManager) return null;
+    const customizations = this.customizationManager.getCustomizations();
+    const icon = customizations.home?.header_button_icon;
+    const path = customizations.home?.header_button_path;
+    return icon && path ? { icon, path } : null;
+  }
+
+  private getCustomButtonHTML(): string {
+    const config = this.getHeaderButtonConfig();
+    if (!config) return '';
+    return `
+      <button class="apple-header-custom-button ${LiquidGlassClasses.headerButton}" data-path="${config.path}">
+        <ha-icon icon="${config.icon}"></ha-icon>
+      </button>
+    `;
+  }
+
+  private navigateToCustomPath(path: string) {
+    // External URLs or absolute HA paths navigate directly
+    if (/^https?:\/\//.test(path) || path.startsWith('/')) {
+      window.location.href = path;
+      return;
+    }
+
+    const currentPath = window.location.pathname;
+    let basePath = '';
+
+    if (currentPath.startsWith('/lovelace/') || currentPath === '/lovelace') {
+      basePath = '/lovelace/';
+    } else {
+      const pathParts = currentPath.split('/').filter(part => part.length > 0);
+      basePath = pathParts.length > 0 ? `/${pathParts[0]}/` : '/lovelace/';
+    }
+
+    const newUrl = `${basePath}${path}`;
+    window.history.pushState(null, '', newUrl);
+    const event = new Event('location-changed', { bubbles: true, composed: true });
+    window.dispatchEvent(event);
+  }
+
+  private attachCustomButtonListener(button: HTMLButtonElement) {
+    button.addEventListener('click', (e: Event) => {
+      e.stopPropagation();
+      const path = button.dataset.path;
+      if (path) this.navigateToCustomPath(path);
+    });
+  }
+
+  /**
+   * Re-reads the custom header button config and creates/updates/removes its DOM
+   * element accordingly. Called after Home Settings saves, since the button's
+   * config lives in customizations rather than HeaderConfig.
+   */
+  refreshCustomButton() {
+    if (!this.headerElement) return;
+    const config = this.getHeaderButtonConfig();
+    let button = this.headerElement.querySelector('.apple-header-custom-button') as HTMLButtonElement | null;
+
+    if (!config) {
+      button?.remove();
+      return;
+    }
+
+    if (!button) {
+      const content = this.headerElement.querySelector('.apple-header-content');
+      const menuButton = this.headerElement.querySelector('.apple-header-menu-button');
+      if (!content) return;
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = this.getCustomButtonHTML().trim();
+      button = wrapper.firstElementChild as HTMLButtonElement;
+      if (menuButton) {
+        content.insertBefore(button, menuButton);
+      } else {
+        content.appendChild(button);
+      }
+      this.attachCustomButtonListener(button);
+    } else {
+      button.querySelector('ha-icon')?.setAttribute('icon', config.icon);
+      button.dataset.path = config.path;
+    }
   }
 
   private getMenuButtonContent(): string {
@@ -763,6 +851,12 @@ export class AppleHeader {
         e.stopPropagation();
         this.openSidebar();
       });
+    }
+
+    // Custom (user-configurable) button click (if it exists)
+    const customButton = this.headerElement?.querySelector('.apple-header-custom-button') as HTMLButtonElement;
+    if (customButton) {
+      this.attachCustomButtonListener(customButton);
     }
 
     // Window resize listener to update button visibility based on mobile/desktop
@@ -1972,6 +2066,29 @@ export class AppleHeader {
         transform: scale(0.97);
       }
 
+      /* Custom (user-configurable) button - positioned just left of the menu button */
+      .apple-header-custom-button {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        right: 64px;
+        z-index: 10;
+        font-family: inherit;
+      }
+
+      .apple-header-custom-button:active {
+        transform: translateY(-50%) scale(0.95);
+      }
+
+      .apple-home-header.group-page .apple-header-custom-button {
+        top: 12px;
+        transform: none;
+      }
+
+      .apple-home-header.group-page .apple-header-custom-button:active {
+        transform: scale(0.97);
+      }
+
       /* RTL positioning for group-page menu button */
       .apple-home-header.group-page.rtl .apple-header-menu-button {
         right: auto !important;
@@ -1983,6 +2100,19 @@ export class AppleHeader {
       .apple-home-header.rtl .apple-header-menu-button {
         right: auto !important;
         left: 16px !important;
+      }
+
+      /* RTL positioning for custom button (mirrors menu button) */
+      .apple-home-header.group-page.rtl .apple-header-custom-button {
+        left: auto !important;
+        right: 64px !important;
+        top: 12px;
+        transform: none;
+      }
+
+      .apple-home-header.rtl .apple-header-custom-button {
+        right: auto !important;
+        left: 64px !important;
       }
 
       /* Mobile adjustments for menu button */
@@ -1997,6 +2127,18 @@ export class AppleHeader {
         .apple-home-header.rtl .apple-header-menu-button {
           right: auto !important;
           left: 12px !important;
+        }
+
+        .apple-header-custom-button {
+          right: 54px;
+          width: 34px;
+          height: 34px;
+          min-width: 34px;
+        }
+
+        .apple-home-header.rtl .apple-header-custom-button {
+          right: auto !important;
+          left: 54px !important;
         }
       }
 

--- a/src/sections/AppleHeader.ts
+++ b/src/sections/AppleHeader.ts
@@ -577,23 +577,30 @@ export class AppleHeader {
   }
 
   private navigateToCustomPath(path: string) {
-    // External URLs or absolute HA paths navigate directly
-    if (/^https?:\/\//.test(path) || path.startsWith('/')) {
+    // Only true external URLs need a real browser navigation. Absolute HA paths
+    // (e.g. to a different dashboard) still go through HA's client-side router
+    // via pushState + location-changed, same as the sidebar does, so the
+    // transition stays smooth instead of showing the HA loading screen.
+    if (/^https?:\/\//.test(path)) {
       window.location.href = path;
       return;
     }
 
-    const currentPath = window.location.pathname;
-    let basePath = '';
+    let newUrl = path;
+    if (!path.startsWith('/')) {
+      const currentPath = window.location.pathname;
+      let basePath = '';
 
-    if (currentPath.startsWith('/lovelace/') || currentPath === '/lovelace') {
-      basePath = '/lovelace/';
-    } else {
-      const pathParts = currentPath.split('/').filter(part => part.length > 0);
-      basePath = pathParts.length > 0 ? `/${pathParts[0]}/` : '/lovelace/';
+      if (currentPath.startsWith('/lovelace/') || currentPath === '/lovelace') {
+        basePath = '/lovelace/';
+      } else {
+        const pathParts = currentPath.split('/').filter(part => part.length > 0);
+        basePath = pathParts.length > 0 ? `/${pathParts[0]}/` : '/lovelace/';
+      }
+
+      newUrl = `${basePath}${path}`;
     }
 
-    const newUrl = `${basePath}${path}`;
     window.history.pushState(null, '', newUrl);
     const event = new Event('location-changed', { bubbles: true, composed: true });
     window.dispatchEvent(event);

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -279,7 +279,11 @@
     "show_cost": "Kosten anzeigen",
     "show_cost_description": "Zeigt Kostenangaben im Energie-Dashboard, sofern verfügbar",
     "show_gas": "Gas anzeigen",
-    "show_gas_description": "Zeigt den Gasverbrauch auf dem Startbildschirm und im Energie-Dashboard, sofern konfiguriert"
+    "show_gas_description": "Zeigt den Gasverbrauch auf dem Startbildschirm und im Energie-Dashboard, sofern konfiguriert",
+    "header_button": "Eigene Menü-Schaltfläche",
+    "header_button_description": "Fügt eine Schaltfläche neben dem Menüsymbol hinzu, die beim Antippen zu einem anderen Dashboard oder einer anderen Seite navigiert",
+    "header_button_icon_placeholder": "Symbol (z. B. mdi:shield-home)",
+    "header_button_path_placeholder": "Pfad (z. B. security oder lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Nicht verfügbar",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -276,7 +276,11 @@
     "show_cost": "Show Cost",
     "show_cost_description": "Show cost figures on the energy dashboard when available",
     "show_gas": "Show Gas",
-    "show_gas_description": "Show gas consumption on the home screen and energy dashboard when configured"
+    "show_gas_description": "Show gas consumption on the home screen and energy dashboard when configured",
+    "header_button": "Custom Menu Button",
+    "header_button_description": "Add one button next to the menu icon that navigates to another dashboard or page when tapped",
+    "header_button_icon_placeholder": "Icon (e.g. mdi:shield-home)",
+    "header_button_path_placeholder": "Path (e.g. security or lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Unavailable",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -278,7 +278,11 @@
     "show_cost": "Mostrar Costo",
     "show_cost_description": "Muestra las cifras de costo en el panel de energía cuando estén disponibles",
     "show_gas": "Mostrar Gas",
-    "show_gas_description": "Muestra el consumo de gas en la pantalla principal y el panel de energía cuando esté configurado"
+    "show_gas_description": "Muestra el consumo de gas en la pantalla principal y el panel de energía cuando esté configurado",
+    "header_button": "Botón de menú personalizado",
+    "header_button_description": "Añade un botón junto al icono del menú que navega a otro panel o página al tocarlo",
+    "header_button_icon_placeholder": "Icono (p. ej. mdi:shield-home)",
+    "header_button_path_placeholder": "Ruta (p. ej. security o lovelace/security)"
   },
   "status_messages": {
     "unavailable": "No disponible",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -277,7 +277,11 @@
     "show_cost": "Afficher le Coût",
     "show_cost_description": "Affiche les montants du coût sur le tableau de bord énergie lorsqu'ils sont disponibles",
     "show_gas": "Afficher le Gaz",
-    "show_gas_description": "Affiche la consommation de gaz sur l'écran d'accueil et le tableau de bord énergie lorsqu'elle est configurée"
+    "show_gas_description": "Affiche la consommation de gaz sur l'écran d'accueil et le tableau de bord énergie lorsqu'elle est configurée",
+    "header_button": "Bouton de menu personnalisé",
+    "header_button_description": "Ajoute un bouton à côté de l'icône du menu qui accède à un autre tableau de bord ou une autre page au toucher",
+    "header_button_icon_placeholder": "Icône (ex. mdi:shield-home)",
+    "header_button_path_placeholder": "Chemin (ex. security ou lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Indisponible",

--- a/src/translations/he.json
+++ b/src/translations/he.json
@@ -277,7 +277,11 @@
     "show_cost": "הצג עלות",
     "show_cost_description": "הצג נתוני עלות בלוח האנרגיה כאשר זמינים",
     "show_gas": "הצג גז",
-    "show_gas_description": "הצג צריכת גז במסך הבית ובלוח האנרגיה כאשר מוגדר"
+    "show_gas_description": "הצג צריכת גז במסך הבית ובלוח האנרגיה כאשר מוגדר",
+    "header_button": "כפתור תפריט מותאם אישית",
+    "header_button_description": "הוסף כפתור אחד ליד סמל התפריט שמנווט ללוח מחוונים או דף אחר בעת הקשה",
+    "header_button_icon_placeholder": "סמל (למשל mdi:shield-home)",
+    "header_button_path_placeholder": "נתיב (למשל security או lovelace/security)"
   },
   "status_messages": {
     "unavailable": "לא זמין",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -279,7 +279,11 @@
     "show_cost": "Mostra Costo",
     "show_cost_description": "Mostra i valori di costo nella dashboard energia quando disponibili",
     "show_gas": "Mostra Gas",
-    "show_gas_description": "Mostra il consumo di gas nella schermata principale e nella dashboard energia quando configurato"
+    "show_gas_description": "Mostra il consumo di gas nella schermata principale e nella dashboard energia quando configurato",
+    "header_button": "Pulsante di menu personalizzato",
+    "header_button_description": "Aggiunge un pulsante accanto all'icona del menu che consente di passare a un'altra dashboard o pagina quando viene toccato",
+    "header_button_icon_placeholder": "Icona (es. mdi:shield-home)",
+    "header_button_path_placeholder": "Percorso (es. security o lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Non disponibile",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -277,7 +277,11 @@
     "show_cost": "Kosten Tonen",
     "show_cost_description": "Toont kostencijfers op het energiedashboard indien beschikbaar",
     "show_gas": "Gas Tonen",
-    "show_gas_description": "Toont gasverbruik op het startscherm en energiedashboard indien geconfigureerd"
+    "show_gas_description": "Toont gasverbruik op het startscherm en energiedashboard indien geconfigureerd",
+    "header_button": "Aangepaste menuknop",
+    "header_button_description": "Voegt een knop naast het menupictogram toe die bij tikken naar een ander dashboard of andere pagina navigeert",
+    "header_button_icon_placeholder": "Pictogram (bijv. mdi:shield-home)",
+    "header_button_path_placeholder": "Pad (bijv. security of lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Niet beschikbaar",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -279,7 +279,11 @@
     "show_cost": "Mostrar Custo",
     "show_cost_description": "Mostra os valores de custo no painel de energia quando disponíveis",
     "show_gas": "Mostrar Gás",
-    "show_gas_description": "Mostra o consumo de gás na tela inicial e no painel de energia quando configurado"
+    "show_gas_description": "Mostra o consumo de gás na tela inicial e no painel de energia quando configurado",
+    "header_button": "Botão de menu personalizado",
+    "header_button_description": "Adiciona um botão junto ao ícone do menu que navega para outro painel ou página ao tocar",
+    "header_button_icon_placeholder": "Ícone (ex. mdi:shield-home)",
+    "header_button_path_placeholder": "Caminho (ex. security ou lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Indisponível",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -279,7 +279,11 @@
     "show_cost": "Показать стоимость",
     "show_cost_description": "Показывает данные о стоимости на панели энергии, если доступны",
     "show_gas": "Показать газ",
-    "show_gas_description": "Показывает потребление газа на главном экране и панели энергии, если настроено"
+    "show_gas_description": "Показывает потребление газа на главном экране и панели энергии, если настроено",
+    "header_button": "Настраиваемая кнопка меню",
+    "header_button_description": "Добавляет кнопку рядом со значком меню, которая при нажатии переходит на другую панель или страницу",
+    "header_button_icon_placeholder": "Значок (напр. mdi:shield-home)",
+    "header_button_path_placeholder": "Путь (напр. security или lovelace/security)"
   },
   "status_messages": {
     "unavailable": "Недоступно",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -277,7 +277,11 @@
     "show_cost": "显示费用",
     "show_cost_description": "在能源仪表板上显示费用数据（如可用）",
     "show_gas": "显示燃气",
-    "show_gas_description": "在主屏幕和能源仪表板上显示燃气消耗（如已配置）"
+    "show_gas_description": "在主屏幕和能源仪表板上显示燃气消耗（如已配置）",
+    "header_button": "自定义菜单按钮",
+    "header_button_description": "在菜单图标旁添加一个按钮，点击后跳转到其他仪表盘或页面",
+    "header_button_icon_placeholder": "图标（例如 mdi:shield-home）",
+    "header_button_path_placeholder": "路径（例如 security 或 lovelace/security）"
   },
   "status_messages": {
     "unavailable": "不可用",

--- a/src/utils/HomeSettingsManager.ts
+++ b/src/utils/HomeSettingsManager.ts
@@ -21,6 +21,8 @@ export interface HomeSettingsData {
   showEnergy?: boolean;
   showCost?: boolean;
   showGas?: boolean;
+  headerButtonIcon?: string;
+  headerButtonPath?: string;
 }
 
 export class HomeSettingsManager {
@@ -97,7 +99,9 @@ export class HomeSettingsManager {
       showSwitches: customizations.home?.show_switches || false,
       showEnergy: customizations.home?.show_energy || false,
       showCost: customizations.home?.show_cost !== false,
-      showGas: customizations.home?.show_gas !== false
+      showGas: customizations.home?.show_gas !== false,
+      headerButtonIcon: customizations.home?.header_button_icon || undefined,
+      headerButtonPath: customizations.home?.header_button_path || undefined
     };
 
     // Create a copy for temporary editing
@@ -116,7 +120,9 @@ export class HomeSettingsManager {
       showSwitches: this.settings.showSwitches,
       showEnergy: this.settings.showEnergy,
       showCost: this.settings.showCost,
-      showGas: this.settings.showGas
+      showGas: this.settings.showGas,
+      headerButtonIcon: this.settings.headerButtonIcon,
+      headerButtonPath: this.settings.headerButtonPath
     };
 
     }
@@ -286,6 +292,27 @@ export class HomeSettingsManager {
           </div>
         </div>
         <p class="settings-section-description">${localize('settings.exclude_from_dashboard_description')}</p>
+      </div>
+
+      <div class="settings-section">
+        <h3 class="settings-section-header">${localize('settings.header_button')}</h3>
+        <div class="settings-card">
+          <input
+            type="text"
+            class="settings-text-input"
+            data-setting="headerButtonIcon"
+            placeholder="${localize('settings.header_button_icon_placeholder')}"
+            value="${this.tempSettings.headerButtonIcon || ''}"
+          />
+          <input
+            type="text"
+            class="settings-text-input"
+            data-setting="headerButtonPath"
+            placeholder="${localize('settings.header_button_path_placeholder')}"
+            value="${this.tempSettings.headerButtonPath || ''}"
+          />
+        </div>
+        <p class="settings-section-description">${localize('settings.header_button_description')}</p>
       </div>
 
       <div class="settings-section">
@@ -683,6 +710,32 @@ export class HomeSettingsManager {
         color: rgba(255, 255, 255, 0.4);
       }
 
+      .settings-text-input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 12px 16px;
+        background: rgba(39, 39, 39, 0.8);
+        border: 1px solid rgba(84, 84, 88, 0.8);
+        border-radius: var(--apple-input-radius, 10px);
+        color: white;
+        font-size: 14px;
+        outline: none;
+        transition: border-color 0.2s ease;
+        margin-top: 16px;
+      }
+
+      .settings-text-input + .settings-text-input {
+        margin-top: 8px;
+      }
+
+      .settings-text-input:focus {
+        border-color: #ffaf00;
+      }
+
+      .settings-text-input::placeholder {
+        color: rgba(255, 255, 255, 0.4);
+      }
+
       .autocomplete-results {
         position: absolute;
         top: 100%;
@@ -992,6 +1045,22 @@ export class HomeSettingsManager {
 
     // Setup background settings
     this.setupBackgroundEventListeners();
+
+    // Setup plain text settings (e.g. custom header button)
+    this.setupTextInputs();
+  }
+
+  private setupTextInputs() {
+    const inputs = this.modal?.querySelectorAll('.settings-text-input');
+    inputs?.forEach(input => {
+      const setting = input.getAttribute('data-setting') as keyof HomeSettingsData;
+      if (!setting) return;
+
+      input.addEventListener('input', (e) => {
+        const value = (e.target as HTMLInputElement).value.trim();
+        (this.tempSettings[setting] as string | undefined) = value || undefined;
+      });
+    });
   }
 
   private setupAutocomplete() {
@@ -1312,7 +1381,9 @@ export class HomeSettingsManager {
       this.settings.showEnergy !== this.tempSettings.showEnergy ||
       this.settings.showCost !== this.tempSettings.showCost ||
       this.settings.showGas !== this.tempSettings.showGas ||
-      this.settings.weatherEntity !== this.tempSettings.weatherEntity;
+      this.settings.weatherEntity !== this.tempSettings.weatherEntity ||
+      this.settings.headerButtonIcon !== this.tempSettings.headerButtonIcon ||
+      this.settings.headerButtonPath !== this.tempSettings.headerButtonPath;
     
     // Apply temporary settings to actual settings
     this.settings.favoriteAccessories = [...this.tempSettings.favoriteAccessories];
@@ -1330,6 +1401,8 @@ export class HomeSettingsManager {
     this.settings.showEnergy = this.tempSettings.showEnergy;
     this.settings.showCost = this.tempSettings.showCost;
     this.settings.showGas = this.tempSettings.showGas;
+    this.settings.headerButtonIcon = this.tempSettings.headerButtonIcon;
+    this.settings.headerButtonPath = this.tempSettings.headerButtonPath;
 
     // Start modal fade immediately (while save happens in parallel)
     if (this.modal) {
@@ -1398,7 +1471,9 @@ export class HomeSettingsManager {
     home.show_energy = this.settings.showEnergy;
     home.show_cost = this.settings.showCost;
     home.show_gas = this.settings.showGas;
-    
+    home.header_button_icon = this.settings.headerButtonIcon || null;
+    home.header_button_path = this.settings.headerButtonPath || null;
+
     const ui = this.customizationManager.getCustomization('ui') || {};
     ui.hide_header = this.settings.hideHeader;
     ui.hide_sidebar = this.settings.hideSidebar;


### PR DESCRIPTION
## Summary
Adds an optional single button next to the header's menu icon, so users can jump straight to another dashboard or page (e.g. a dedicated Security dashboard) without going through the dropdown menu.

- Configured entirely from the existing Home Settings modal (gear icon) - no YAML editing required: an icon field (`mdi:...`) and a navigation path/URL field.
- Both fields must be set for the button to appear; clearing either removes it.
- Storage follows the existing flat `home.*` customization convention (`home.header_button_icon` / `home.header_button_path`), saved via the existing batch-save path.
- Navigation-only (no service calls): a path with a leading `/` navigates to a different dashboard (e.g. `/security-dashboard/security`) via HA's client-side router (`pushState` + `location-changed`, the same mechanism the sidebar uses) so the transition stays smooth instead of showing the HA loading screen. A path without a leading slash resolves relative to the current dashboard's base path (e.g. `security` opens that dashboard's own Security group page). An `http(s)://` URL does a real browser navigation, since that's the only case that actually needs one.
- Added translation strings for the new settings section in all 10 supported languages.

Verified live on a real dashboard (Zone Z): configured the button with an absolute path to a separate, previously-built security dashboard. Initial version used `window.location.href` for absolute paths, which caused a full page reload / HA loading-screen flash on navigation; fixed to route through pushState + location-changed instead, confirmed smooth afterward.

## Test plan
- [x] Open Home Settings, set an icon (e.g. `mdi:shield-home`) and an absolute path (e.g. `/security-dashboard/security`); Save; confirm the button appears next to the menu icon and navigates smoothly (no full reload/loading screen) on tap. (Verified live.)
- [ ] Set a relative path (e.g. `security`) and confirm it opens the current dashboard's own Security group page.
- [ ] Clear either field and Save; confirm the button disappears.
- [ ] Set an `https://` URL; confirm it navigates correctly (real browser navigation is expected/fine here).
- [ ] Confirm the button also renders correctly on Room/Scenes/Cameras pages (wherever the menu button appears), and is positioned correctly in RTL layout and at mobile widths.