### PR TITLE
fix(weather): fall back to subscribe_forecast when get_forecasts is unavailable

### DIFF
--- a/src/sections/WeatherSection.ts
+++ b/src/sections/WeatherSection.ts
@@ -328,6 +328,9 @@ export class WeatherSection {
       return this.forecastCache.data;
     }
 
+    // `weather/get_forecasts` (one-shot) was removed on some HA versions in favor of
+    // `weather/subscribe_forecast` (subscription-only) - try the older, cheaper call
+    // first for backward compatibility, then fall back to subscribing for one event.
     try {
       const result = await hass.callWS({
         type: 'weather/get_forecasts',
@@ -340,7 +343,17 @@ export class WeatherSection {
         return forecasts;
       }
     } catch {
-      // WS call not available
+      // WS command not available on this HA version
+    }
+
+    try {
+      const forecasts = await this.subscribeForecastOnce(hass, entityId);
+      if (forecasts.length > 0) {
+        this.forecastCache = { entityId, data: forecasts, timestamp: Date.now() };
+        return forecasts;
+      }
+    } catch {
+      // Subscription not available either
     }
 
     const attrForecast = stateObj.attributes?.forecast;
@@ -350,6 +363,40 @@ export class WeatherSection {
     }
 
     return [];
+  }
+
+  /**
+   * Subscribes to `weather/subscribe_forecast` just long enough to grab one
+   * forecast payload, then unsubscribes - a one-shot fetch built on top of the
+   * subscription-only API that current HA versions require.
+   */
+  private subscribeForecastOnce(hass: any, entityId: string): Promise<ForecastDay[]> {
+    return new Promise((resolve, reject) => {
+      let unsubscribe: (() => void) | undefined;
+      let settled = false;
+
+      const finish = (result: ForecastDay[] | Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        unsubscribe?.();
+        if (result instanceof Error) reject(result);
+        else resolve(result);
+      };
+
+      const timeoutId = setTimeout(() => finish(new Error('Forecast subscription timed out')), 5000);
+
+      hass.connection
+        .subscribeMessage(
+          (event: { forecast?: ForecastDay[] }) => finish(event?.forecast || []),
+          { type: 'weather/subscribe_forecast', entity_id: entityId, forecast_type: 'daily' }
+        )
+        .then((unsub: () => void) => {
+          unsubscribe = unsub;
+          if (settled) unsub();
+        })
+        .catch((error: unknown) => finish(error instanceof Error ? error : new Error(String(error))));
+    });
   }
 
   private injectStyles(container: HTMLElement): void {


### PR DESCRIPTION
## Summary
On current Home Assistant versions, the one-shot `weather/get_forecasts` WS command that `WeatherSection.fetchForecast()` calls returns `unknown_command` - only the subscription-based `weather/subscribe_forecast` is supported now. That failure was silently swallowed by the existing try/catch, and the legacy `forecast` state attribute fallback is also gone on modern weather integrations, so `fetchForecast()` returned an empty array. Result: the 5-day forecast bar chart section never rendered, leaving a large empty gap at the bottom of the weather card - most visible on wide/landscape layouts, where that unused space has nowhere else to go.

- Added `subscribeForecastOnce()`: subscribes to `weather/subscribe_forecast` just long enough to receive one forecast payload, then unsubscribes immediately - effectively a one-shot fetch built on top of the subscription-only API, with a 5s timeout as a safety net.
- `get_forecasts` is still tried first (cheap, and still works on some HA versions/integrations), falling through to the new subscription path, then to the legacy state attribute, same layered-fallback shape as before.
- No visual/layout changes - once forecast data is actually available, the existing forecast-row rendering takes over as designed.

Verified live: on HA 2026.7.4, `get_forecasts` returns `unknown_command` while `subscribe_forecast` returns a full 5-day forecast; confirmed the forecast bars now render on the Home page weather card where they were previously missing.

## Test plan
- [x] On an HA version where `get_forecasts` fails, confirm the weather card now shows the 5-day forecast bars instead of empty space. (Verified live.)
- [ ] On an HA version where `get_forecasts` still succeeds, confirm no behavior change (fast path still used).
- [ ] Confirm forecast data is still cached for `WeatherSection.CACHE_TTL` and not re-fetched on every render.